### PR TITLE
Render: Change from single- to multi-page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
     * - **bugfix** Metadata: Fix typo in status key
     * - Render: Separate posts with <hr>
     * - Render: Sort post from latest to oldest
+    * Render: Change from single- to multi-page site
 
 *Not released yet*
 


### PR DESCRIPTION
Each post will be now rendered in its own file named by its slug.
The index file is now a list of links to the posts sorted by creation
time.

