### PR TITLE
cmd/list: fix file count condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
+# For next release
+  * **Raphael Pour**
+    * **bugfix** cmd/list: fix file count condition to check if a post directory has enough files
+
+*Not released yet*
+
 # Minor Release v0.3.0 (2022-03-23)
   * **Raphael Pour**
     * render: add navigation with previous+next post and home
   * **Tch1b0**
     * render: add syntax-highlighting for code-blocks
+    
+
 *Released by Raphael Pour <info@raphaelpour.de>*
 
 # Minor Release v0.2.0 (2022-01-13)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -51,7 +51,7 @@ var listCmd = &cobra.Command{
 				return fmt.Errorf("Error reading post path of %s: %s", postPath, err)
 			}
 
-			if len(files) != 2 {
+			if len(files) < 2 {
 				return fmt.Errorf(
 					"Unexpected count of files in post path %s. Found: %d",
 					postPath,


### PR DESCRIPTION
Since with image-support there can be more than two files inside a post
directory now, the file count condition needs to be adjusted. Now at
least two files must be present.

## bug report

Previously the list command broke when a post had more than two files:

```bash
$ blogctl list -p ../blog/site/
Creation date                  | Status  |Title
-------------------------------+---------+---------------
2021-01-12 12:45:38 +0100 CET | public | --version always
2020-11-24 13:09:39 +0100 CET | public | AoC
2020-12-17 16:44:07 +0100 CET | draft  | AoC 2020 Day 4
2020-12-01 13:03:45 +0100 CET | public | AoC day1
2020-12-07 18:35:56 +0100 CET | public | AoC day7
Unexpected count of files in post path blog/aoc21-9-3d-print-of-cave-height-map. Found: 5
$ ls blog/aoc21-9-3d-print-of-cave-height-map/
content.md  metadata.json  result1.jpg  result2.jpg  result3.jpg