### PR TITLE
cmd/list: render table via tablewriter (replace diy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     * metadata: pretty render initial metadata
     * cmd/render, config: add chill-files list containing arbitrary files that just get copied to the root of the output dir
     * cmd: add admin/rewrite-metadata command to pretty print all old metadata files
+    * cmd/list: render table via tablewriter
 
 *Not released yet*
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -22,8 +22,10 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/RaphaelPour/blogctl/internal/metadata"
+	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
+
+	"github.com/RaphaelPour/blogctl/internal/metadata"
 )
 
 // listCmd represents the list command
@@ -37,8 +39,8 @@ var listCmd = &cobra.Command{
 			return fmt.Errorf("Error reading blog path: %s", err)
 		}
 
-		fmt.Println("Creation date                  | Status  | Static | Title")
-		fmt.Println("-------------------------------+---------+--------+---------------")
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetHeader([]string{"Creation date", "Status", "Static", "Title"})
 
 		for _, dir := range postDirs {
 			if !dir.IsDir() {
@@ -64,14 +66,16 @@ var listCmd = &cobra.Command{
 				return err
 			}
 
-			fmt.Printf("%-30s | %-6s | %-6v | %s\n",
+			table.Append([]string{
 				time.Unix(metadata.CreatedAt, 0).String(),
 				metadata.Status,
-				metadata.Static,
+				fmt.Sprintf("%t", metadata.Static),
 				metadata.Title,
-			)
+			})
 
 		}
+
+		table.Render()
 
 		return nil
 	},

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gomarkdown/markdown v0.0.0-20211212230626-5af6ad2f47df
 	github.com/gorilla/feeds v1.1.1
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.8.4
 )
@@ -18,6 +19,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.0.0-20220111092808-5a964db01320 // indirect

--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,8 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
@@ -285,6 +287,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=

--- a/spec.rb
+++ b/spec.rb
@@ -109,7 +109,7 @@ describe 'CLI' do
 
     it 'lists zero posts' do
       out, _, _ = blogctl("list -p #{blog_path}")
-      expect(out).to match(/^Creation data\s*|\s*Title$/)
+      expect(out).to match(/^| CREATION DATE | STATUS | STATIC | TITLE |$/)
     end
 
     it 'lists one post' do


### PR DESCRIPTION
Before:
```
 $ ci-build/blogctl -p ../blog list
Creation date                  | Status  | Static | Title
-------------------------------+---------+--------+---------------
2020-09-25 17:28:02 +0200 CEST | public | false  | Avoid distraction tools
2023-07-22 11:15:49 +0200 CEST | draft  | false  | lol
2020-12-05 16:49:07 +0100 CET  | public | false  | TEST
2020-10-13 17:00:16 +0200 CEST | public | false  | use-case heavy projects
```

After:
```
$ ci-build/blogctl -p ../blog list
+--------------------------------+--------+--------+-------------------------+
|         CREATION DATE          | STATUS | STATIC |          TITLE          |
+--------------------------------+--------+--------+-------------------------+
| 2020-09-25 17:28:02 +0200 CEST | public | false  | Avoid distraction tools |
| 2023-07-22 11:15:49 +0200 CEST | draft  | false  | lol                     |
| 2020-12-05 16:49:07 +0100 CET  | public | false  | TEST                    |
| 2020-10-13 17:00:16 +0200 CEST | public | false  | use-case heavy projects |
+--------------------------------+--------+--------+-------------------------+
```